### PR TITLE
x/liquidstake module fix rebalancing for low bond ratio.

### DIFF
--- a/x/liquidstake/keeper/rebalancing.go
+++ b/x/liquidstake/keeper/rebalancing.go
@@ -230,6 +230,8 @@ func (k Keeper) AutocompoundStakingRewards(ctx sdk.Context, whitelistedValsMap t
 
 	// calculate the hourly APY
 	bondRatio := math.LegacyDec(bondedTokens).Quo(math.LegacyDec(totalSupply))
+	bondRatio = bondRatio.Add(math.LegacySmallestDec())
+
 	hourlyApy := inflation.Quo(bondRatio).
 		Quo(types.DefaultLimitAutocompoundPeriodDays).
 		Quo(types.DefaultLimitAutocompoundPeriodHours)


### PR DESCRIPTION
# Description

A ratio between total bonded(staked) tokens, and total tokens in the network used for calculating upper limit for autocompound stake from module proxy account for checking the inflation limit. Which in case of difference in several powers between the values ends up in zero.

Which results in zero division error.
Fix is quite trivial: adding epsilon for the bond ratio fixes the problem.

Since those small change doesn't affect database/consensus in any way/i.e have no breaking changes unless the case is hit, upgrade mechanism could be omitted and node could be silently updated whenever validators desire to, or with the next upgrade. Alternatively we could prepare separate release for the mainnet.

## Steps to reproduce:

`INITIAL_BALANCE=1000000000000000000000000000000000000000000000000000 make localnet`
