### PR TITLE
fix: Use CallerAddress instead of Origin in authz methods (HAL-01)

### DIFF
--- a/precompiles/ics20/ics20.go
+++ b/precompiles/ics20/ics20.go
@@ -110,13 +110,13 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 			// TODO Approval transactions => need cosmos-sdk v0.46 & ibc-go v6.2.0
 			// Authorization Methods:
 			case authorization.ApproveMethod:
-				bz, err = p.Approve(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.Approve(ctx, contract.CallerAddress, stateDB, method, args)
 			case authorization.RevokeMethod:
-				bz, err = p.Revoke(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.Revoke(ctx, contract.CallerAddress, stateDB, method, args)
 			case authorization.IncreaseAllowanceMethod:
-				bz, err = p.IncreaseAllowance(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.IncreaseAllowance(ctx, contract.CallerAddress, stateDB, method, args)
 			case authorization.DecreaseAllowanceMethod:
-				bz, err = p.DecreaseAllowance(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.DecreaseAllowance(ctx, contract.CallerAddress, stateDB, method, args)
 			// ICS20 transactions
 			case TransferMethod:
 				bz, err = p.Transfer(ctx, evm.Origin, contract, stateDB, method, args)

--- a/precompiles/staking/staking.go
+++ b/precompiles/staking/staking.go
@@ -101,13 +101,13 @@ func (p Precompile) Run(evm *vm.EVM, contract *vm.Contract, readOnly bool) (bz [
 			switch method.Name {
 			// Authorization transactions
 			case authorization.ApproveMethod:
-				bz, err = p.Approve(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.Approve(ctx, contract.CallerAddress, stateDB, method, args)
 			case authorization.RevokeMethod:
-				bz, err = p.Revoke(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.Revoke(ctx, contract.CallerAddress, stateDB, method, args)
 			case authorization.IncreaseAllowanceMethod:
-				bz, err = p.IncreaseAllowance(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.IncreaseAllowance(ctx, contract.CallerAddress, stateDB, method, args)
 			case authorization.DecreaseAllowanceMethod:
-				bz, err = p.DecreaseAllowance(ctx, evm.Origin, stateDB, method, args)
+				bz, err = p.DecreaseAllowance(ctx, contract.CallerAddress, stateDB, method, args)
 			// Staking transactions
 			case CreateValidatorMethod:
 				bz, err = p.CreateValidator(ctx, evm.Origin, contract, stateDB, method, args)


### PR DESCRIPTION
A hot-fix is applied to the staking precompile's authorization handling. Previously, a missing or incorrectly scoped authorization check could allow a caller to exercise delegation management rights they had not explicitly been granted.